### PR TITLE
fix issues with toolbox showcreator

### DIFF
--- a/addons/gmc-toolbox/show_creator/MPFShowCreator.gd
+++ b/addons/gmc-toolbox/show_creator/MPFShowCreator.gd
@@ -54,15 +54,16 @@ func _enter_tree():
 	self.add_child(playfield_scene)
 	if self.name == "MPFShowCreator":
 		render_animation = true
-		show_yaml_path = config.get_value("show_creator", "show_yaml_path", false)
-		assert(show_yaml_path, "Config missing show YAML path")
-		assert(DirAccess.dir_exists_absolute(show_yaml_path), "Show YAML path %s does not exist" % show_yaml_path)
+		var show_output_yaml_path: Variant = config.get_value("show_creator", "show_yaml_path", false)
+		assert(show_output_yaml_path, "Config missing show YAML path")
+		assert(DirAccess.dir_exists_absolute(show_output_yaml_path), "Show YAML path %s does not exist" % show_output_yaml_path)
+		self.show_yaml_path = show_output_yaml_path
 	if not render_animation:
 		print("No render animaiton")
 		return
 
 	if config.has_section_key("show_creator", "animation"):
-			animation_name = config.get_value("show_creator", "animation")
+		animation_name = config.get_value("show_creator", "animation")
 
 	fps = config.get_value("show_creator", "fps", 30)
 	strip_unchanged_lights = config.get_value("show_creator", "strip_lights", true)
@@ -93,7 +94,6 @@ func _ready():
 	animation_player = self.playfield_scene.animation_player
 	assert(animation_player, "No AnimationPlayer node attached to the GMCPlayfield root.")
 	assert(animation_player.has_animation(animation_name), "AnimationPlayer has no animation named '%s'" % animation_name)
-
 
 	if not self.lights:
 		if self.tags:
@@ -135,7 +135,7 @@ func _run_animation():
 		self.animation_player.advance(self.spf)
 
 func register_light(light: GMCLight):
-	print("Light %s has position %s on scene size %s" % [light, light.position, self.playfield_scene.size])
+	#print("Light %s has position %s on scene size %s" % [light, light.position, self.playfield_scene.size])
 	if light.position.x < 0 or light.position.y < 0 or light.position.x > self.playfield_scene.size.x or light.position.y > self.playfield_scene.size.y:
 		# In the editor, include all lights
 		if not Engine.is_editor_hint():
@@ -197,5 +197,8 @@ func finish():
 	for key in self.preview.keys():
 		self.config.set_value("preview", key, self.preview[key])
 	self.config.save(CONFIG_PATH)
-	OS.shell_show_in_file_manager(self.file_path)
+	var open_containing_folder: bool = config.get_value("show_creator", "open_folder", true)
+	if open_containing_folder:
+		OS.shell_show_in_file_manager(ProjectSettings.globalize_path(file_path))
+
 	get_tree().quit()

--- a/addons/gmc-toolbox/show_creator_dock.gd
+++ b/addons/gmc-toolbox/show_creator_dock.gd
@@ -142,7 +142,9 @@ func _load_lights():
 					self.tags.append(tag)
 
 	for child in tags_container.get_children():
+		tags_container.remove_child(child)
 		child.queue_free()
+
 	for tag in self.tags:
 		var tag_box = CheckBox.new()
 		tag_box.text = tag

--- a/addons/gmc-toolbox/show_creator_dock.gd
+++ b/addons/gmc-toolbox/show_creator_dock.gd
@@ -156,18 +156,24 @@ func _select_show_scene():
 	dialog.file_mode = FileDialog.FILE_MODE_OPEN_FILE
 	dialog.access = FileDialog.ACCESS_RESOURCES
 	self.add_child(dialog)
-	dialog.popup_centered(Vector2i(1100, 900))
-	var path = await dialog.file_selected
-	self._save_show_scene(path)
+	dialog.popup_centered(get_viewport().size * .5)
+	dialog.canceled.connect(func(): dialog.queue_free())
+	dialog.file_selected.connect(func(path):
+		self._save_show_scene(path)
+		dialog.queue_free()
+	)
 
 func _select_show_output() -> void:
 	var dialog := FileDialog.new()
 	dialog.file_mode = FileDialog.FILE_MODE_OPEN_DIR
 	dialog.access = FileDialog.ACCESS_FILESYSTEM
 	self.add_child(dialog)
-	dialog.popup_centered(Vector2i(1100, 900))
-	var path = await dialog.dir_selected
-	self._save_show_output(path)
+	dialog.popup_centered(get_viewport().size * .5)
+	dialog.canceled.connect(func(): dialog.queue_free())
+	dialog.dir_selected.connect(func(path):
+		self._save_show_output(path)
+		dialog.queue_free()
+	)
 
 func _save_show_scene(path):
 	self.config.set_value("show_creator", "show_scene", path)

--- a/addons/gmc-toolbox/show_creator_dock.tscn
+++ b/addons/gmc-toolbox/show_creator_dock.tscn
@@ -54,7 +54,7 @@ text = "ShowCreator Scene"
 [node name="edit_show_scene" type="LineEdit" parent="MainVContainer/TopHContainer/LeftVContainer/container_show_scene"]
 layout_mode = 2
 size_flags_horizontal = 3
-text = "res://monitor/playfield.tscn"
+text = ""
 placeholder_text = "No Scene Selected"
 
 [node name="button_show_scene" type="Button" parent="MainVContainer/TopHContainer/LeftVContainer/container_show_scene"]

--- a/addons/gmc-toolbox/show_creator_dock.tscn
+++ b/addons/gmc-toolbox/show_creator_dock.tscn
@@ -64,14 +64,28 @@ text = "Select Scene"
 [node name="HSeparator" type="HSeparator" parent="MainVContainer/TopHContainer/LeftVContainer"]
 layout_mode = 2
 
+[node name="container_show_output" type="HBoxContainer" parent="MainVContainer/TopHContainer/LeftVContainer"]
+layout_mode = 2
+
+[node name="label_show_output" type="Label" parent="MainVContainer/TopHContainer/LeftVContainer/container_show_output"]
+layout_mode = 2
+text = "ShowCreator Output"
+
+[node name="edit_show_output" type="LineEdit" parent="MainVContainer/TopHContainer/LeftVContainer/container_show_output"]
+layout_mode = 2
+size_flags_horizontal = 3
+placeholder_text = "No Output Folder Selected"
+
+[node name="button_show_output" type="Button" parent="MainVContainer/TopHContainer/LeftVContainer/container_show_output"]
+layout_mode = 2
+text = "Select Folder"
+
+
 [node name="container_generators" type="HBoxContainer" parent="MainVContainer/TopHContainer/LeftVContainer"]
 layout_mode = 2
 
-[node name="button_generate_lights" type="Button" parent="MainVContainer/TopHContainer/LeftVContainer/container_generators"]
-layout_mode = 2
-text = "  Refresh Lights  "
-
 [node name="button_save_light_positions" type="Button" parent="MainVContainer/TopHContainer/LeftVContainer/container_generators"]
+visible = false
 layout_mode = 2
 text = "  Save Light Positions  "
 
@@ -84,6 +98,10 @@ text = "  Generate Show Creator Scene  "
 [node name="Control" type="Control" parent="MainVContainer/TopHContainer/LeftVContainer/container_generators"]
 layout_mode = 2
 size_flags_horizontal = 3
+
+[node name="button_generate_lights" type="Button" parent="MainVContainer/TopHContainer/LeftVContainer/container_generators"]
+layout_mode = 2
+text = "  Refresh Lights  "
 
 [node name="button_refresh_animations" type="Button" parent="MainVContainer/TopHContainer/LeftVContainer/container_generators"]
 layout_mode = 2
@@ -124,6 +142,10 @@ text = "Use Alpha Channel"
 layout_mode = 2
 button_pressed = true
 text = "Debugging"
+
+[node name="button_open_folder" type="CheckBox" parent="MainVContainer/TopHContainer/LeftVContainer/BottomFContainer"]
+layout_mode = 2
+text = "Open Containing Folder"
 
 [node name="VSeparator" type="VSeparator" parent="MainVContainer/TopHContainer"]
 custom_minimum_size = Vector2(40, 2.08165e-12)
@@ -206,3 +228,4 @@ layout_mode = 2
 
 [node name="HSeparator" type="HSeparator" parent="MainVContainer"]
 layout_mode = 2
+

--- a/addons/gmc-toolbox/toolbox_dock.gd
+++ b/addons/gmc-toolbox/toolbox_dock.gd
@@ -187,7 +187,7 @@ func _generate_scene():
 
 
 func _select_mpf_config(section: String):
-	push_error("Select MPF config for %s" % section)
+	debug_log("Select MPF config for %s" % section)
 	var dialog = FileDialog.new()
 	dialog.file_mode = FileDialog.FILE_MODE_OPEN_FILE
 	dialog.access = FileDialog.ACCESS_FILESYSTEM

--- a/addons/gmc-toolbox/toolbox_dock.gd
+++ b/addons/gmc-toolbox/toolbox_dock.gd
@@ -192,9 +192,13 @@ func _select_mpf_config(section: String):
 	dialog.file_mode = FileDialog.FILE_MODE_OPEN_FILE
 	dialog.access = FileDialog.ACCESS_FILESYSTEM
 	self.add_child(dialog)
-	dialog.popup_centered(Vector2i(1100, 900))
-	var path = await dialog.file_selected
-	self._save_mpf_config(path, section)
+	dialog.popup_centered(get_viewport().size * .5)
+	dialog.canceled.connect(func(): dialog.queue_free())
+	dialog.file_selected.connect(func(path):
+		self._save_mpf_config(path, section)
+		dialog.queue_free()
+	)
+
 
 func _save_mpf_config(path, section):
 	self.config.set_value("show_creator", "mpf_%s_config" % section, path)
@@ -208,9 +212,12 @@ func _select_playfield_scene():
 	dialog.file_mode = FileDialog.FILE_MODE_OPEN_FILE
 	dialog.access = FileDialog.ACCESS_RESOURCES
 	self.add_child(dialog)
-	dialog.popup_centered(Vector2i(1100, 900))
-	var path = await dialog.file_selected
-	self._save_playfield_scene(path)
+	dialog.popup_centered(get_viewport().size * .5)
+	dialog.canceled.connect(func(): dialog.queue_free())
+	dialog.file_selected.connect(func(path):
+		self._save_playfield_scene(path)
+		dialog.queue_free()
+	)
 
 func _save_playfield_scene(path):
 	self.config.set_value("show_creator", "playfield_scene", path)

--- a/addons/gmc-toolbox/toolbox_dock.gd
+++ b/addons/gmc-toolbox/toolbox_dock.gd
@@ -87,6 +87,10 @@ func _generate(group, parent_node: Control = null):
 			parent_node.add_child(item_child)
 			item_child.owner = scene
 		# Tags may have changed, so set that even on existing lights
+		if item_child.global_position == Vector2(-1,-1):
+			debug_log("Trying to set postion from config file")
+			item_child.restore(self[group][i])
+
 		item_child.tags = self[group][i].tags
 
 	debug_log("Added %s %s to the scene %s" % [parent_node.get_child_count(), group, edit_playfield_scene.text])
@@ -254,7 +258,7 @@ func parse_mpf_config(section_name: String):
 			if indent_check == 0:
 				current_item = line_data[0]
 				debug_log(" - Found a %s '%s'" % [section_name, current_item])
-				collection[current_item] = { "tags": []}
+				collection[current_item] = { "tags": [], "position": Vector2(-1, -1)}
 			# If the check is larger, there is more than a delimiter and this is part of the item
 			elif indent_check > 0:
 				# Clear out any inline comments and extra whitespace
@@ -266,6 +270,10 @@ func parse_mpf_config(section_name: String):
 							self.tags[tag] = []
 						self.tags[tag].append(current_item)
 						collection[current_item]["tags"].append(tag)
+				if line_data[0] == "x":
+					collection[current_item]["position"].x = float(line_data[1])
+				if line_data[0] == "y":
+					collection[current_item]["position"].y = float(line_data[1])
 			# If the check is smaller, there is less than a delimiter and we are done with this section
 			else:
 				is_in_section = false

--- a/addons/gmc-toolbox/toolbox_dock.tscn
+++ b/addons/gmc-toolbox/toolbox_dock.tscn
@@ -51,7 +51,7 @@ text = "MPF lights: Config File"
 [node name="edit_mpf_lights_config" type="LineEdit" parent="MainVContainer/TopHContainer/LeftVContainer/container_mpf_lights_config"]
 layout_mode = 2
 size_flags_horizontal = 3
-text = "C:/Users/carr-/Documents/development/darkchaos/glf_mpf/config/lights.yaml"
+text = ""
 placeholder_text = "No File Selected"
 
 [node name="button_mpf_lights_config" type="Button" parent="MainVContainer/TopHContainer/LeftVContainer/container_mpf_lights_config"]
@@ -68,7 +68,7 @@ text = "MPF switches: Config File"
 [node name="edit_mpf_switches_config" type="LineEdit" parent="MainVContainer/TopHContainer/LeftVContainer/container_mpf_switches_config"]
 layout_mode = 2
 size_flags_horizontal = 3
-text = "C:/Users/carr-/Documents/development/darkchaos/glf_mpf/config/switches.yaml"
+text = ""
 placeholder_text = "No File Selected"
 
 [node name="button_mpf_switches_config" type="Button" parent="MainVContainer/TopHContainer/LeftVContainer/container_mpf_switches_config"]
@@ -85,7 +85,7 @@ text = "GMCPlayfield Scene"
 [node name="edit_playfield_scene" type="LineEdit" parent="MainVContainer/TopHContainer/LeftVContainer/container_playfield_scene"]
 layout_mode = 2
 size_flags_horizontal = 3
-text = "res://monitor/playfield.tscn"
+text = ""
 placeholder_text = "No Scene Selected"
 
 [node name="button_playfield_scene" type="Button" parent="MainVContainer/TopHContainer/LeftVContainer/container_playfield_scene"]

--- a/addons/gmc-toolbox/toolbox_dock.tscn
+++ b/addons/gmc-toolbox/toolbox_dock.tscn
@@ -1,9 +1,6 @@
-[gd_scene load_steps=5 format=3 uid="uid://b4tyyjcjwxj7d"]
+[gd_scene load_steps=4 format=3 uid="uid://b4tyyjcjwxj7d"]
 
 [ext_resource type="Script" path="res://addons/gmc-toolbox/toolbox_dock.gd" id="1_ufccj"]
-
-[sub_resource type="StyleBoxFlat" id="StyleBoxFlat_ln2sr"]
-bg_color = Color(0.188235, 0.188235, 0.188235, 1)
 
 [sub_resource type="StyleBoxFlat" id="StyleBoxFlat_x17sv"]
 bg_color = Color(1, 0.462745, 0.219608, 1)
@@ -54,7 +51,7 @@ text = "MPF lights: Config File"
 [node name="edit_mpf_lights_config" type="LineEdit" parent="MainVContainer/TopHContainer/LeftVContainer/container_mpf_lights_config"]
 layout_mode = 2
 size_flags_horizontal = 3
-text = "/Users/Anthony/Git/bmo-game/config/config_lights.yaml"
+text = "C:/Users/carr-/Documents/development/darkchaos/glf_mpf/config/lights.yaml"
 placeholder_text = "No File Selected"
 
 [node name="button_mpf_lights_config" type="Button" parent="MainVContainer/TopHContainer/LeftVContainer/container_mpf_lights_config"]
@@ -71,7 +68,7 @@ text = "MPF switches: Config File"
 [node name="edit_mpf_switches_config" type="LineEdit" parent="MainVContainer/TopHContainer/LeftVContainer/container_mpf_switches_config"]
 layout_mode = 2
 size_flags_horizontal = 3
-text = "/Users/Anthony/Git/bmo-game/config/config_switches.yaml"
+text = "C:/Users/carr-/Documents/development/darkchaos/glf_mpf/config/switches.yaml"
 placeholder_text = "No File Selected"
 
 [node name="button_mpf_switches_config" type="Button" parent="MainVContainer/TopHContainer/LeftVContainer/container_mpf_switches_config"]
@@ -154,79 +151,18 @@ text = "Debugging"
 custom_minimum_size = Vector2(40, 2.08165e-12)
 layout_mode = 2
 
-[node name="CenterVContainer" type="VBoxContainer" parent="MainVContainer/TopHContainer"]
-visible = false
-layout_mode = 2
-
-[node name="Label" type="Label" parent="MainVContainer/TopHContainer/CenterVContainer"]
-layout_mode = 2
-text = "Tags:"
-
-[node name="ScrollContainer" type="ScrollContainer" parent="MainVContainer/TopHContainer/CenterVContainer"]
-custom_minimum_size = Vector2(200, 2.08165e-12)
-layout_mode = 2
-size_flags_vertical = 3
-theme_override_styles/panel = SubResource("StyleBoxFlat_ln2sr")
-
-[node name="tag_checks" type="VBoxContainer" parent="MainVContainer/TopHContainer/CenterVContainer/ScrollContainer"]
-layout_mode = 2
-size_flags_horizontal = 3
-size_flags_vertical = 3
-
-[node name="TagsHContainer" type="HBoxContainer" parent="MainVContainer/TopHContainer/CenterVContainer"]
-layout_mode = 2
-
-[node name="button_tags_select_all" type="Button" parent="MainVContainer/TopHContainer/CenterVContainer/TagsHContainer"]
-layout_mode = 2
-text = "Select All"
-
-[node name="Control" type="Control" parent="MainVContainer/TopHContainer/CenterVContainer/TagsHContainer"]
-layout_mode = 2
-size_flags_horizontal = 3
-
-[node name="button_tags_deselect_all" type="Button" parent="MainVContainer/TopHContainer/CenterVContainer/TagsHContainer"]
-layout_mode = 2
-text = "Deselect All"
-
-[node name="VSeparator2" type="VSeparator" parent="MainVContainer/TopHContainer"]
-custom_minimum_size = Vector2(40, 2.08165e-12)
-layout_mode = 2
-
 [node name="RightVContainer" type="VBoxContainer" parent="MainVContainer/TopHContainer"]
-layout_mode = 2
-
-[node name="label_animation_names" type="Label" parent="MainVContainer/TopHContainer/RightVContainer"]
-layout_mode = 2
-text = "Animation to Generate:"
-
-[node name="button_animation_names" type="OptionButton" parent="MainVContainer/TopHContainer/RightVContainer"]
-layout_mode = 2
-
-[node name="Control" type="Control" parent="MainVContainer/TopHContainer/RightVContainer"]
-custom_minimum_size = Vector2(2.08165e-12, 20)
 layout_mode = 2
 
 [node name="button_launch_monitor" type="Button" parent="MainVContainer/TopHContainer/RightVContainer"]
 layout_mode = 2
 theme_override_styles/hover = SubResource("StyleBoxFlat_x17sv")
 theme_override_styles/normal = SubResource("StyleBoxFlat_rfgoc")
-text = "LAUNCH
+text = "LAUNCH 
 MONITOR"
 
-[node name="Control2" type="Control" parent="MainVContainer/TopHContainer/RightVContainer"]
-custom_minimum_size = Vector2(2.08165e-12, 20)
-layout_mode = 2
-
-[node name="button_preview_show" type="Button" parent="MainVContainer/TopHContainer/RightVContainer"]
-layout_mode = 2
-text = "Preview Last Show"
-
-[node name="Control3" type="Control" parent="MainVContainer/TopHContainer/RightVContainer"]
-custom_minimum_size = Vector2(2.08165e-12, 20)
-layout_mode = 2
-
-[node name="Control" type="Control" parent="MainVContainer/TopHContainer"]
-custom_minimum_size = Vector2(20, 2.08165e-12)
+[node name="VSeparator2" type="VSeparator" parent="MainVContainer/TopHContainer"]
+custom_minimum_size = Vector2(40, 2.08165e-12)
 layout_mode = 2
 
 [node name="HSeparator" type="HSeparator" parent="MainVContainer"]


### PR DESCRIPTION
This PR addresses the following issues presently with the showcreator section of the toolkit.

Fixes missing output path param. show_yaml_path is missing from the config file with no way other than manually adding it. This adds a option to choose a output directory to the show creator dock.

Fixes tags container. Tag are not currently being processed and displayed in the show creator tab. This reads the tags from the GMCLight nodes in the show scene.

Adds option to open the output folder after animation is generated. Rather than always opening the show output folder this allows the user the option.

Tidies up Toolbox Dock. Removes the show creator elements from the toolbox dock.